### PR TITLE
Secure assets behind proxy

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -30,7 +30,8 @@ const envVars = [
   { name: 'AssetStore', envVar: 'ASSET_STORE', _default: 'GCS' }, // one of ['GCS'] (and later perhaps S3, etc.)
   { name: 'AssetStoreBucket', envVar: 'ASSET_STORE_BUCKET' },
   { name: 'SlackChannelUrl', envVar: 'SLACK_CHANNEL_URL' },
-  { name: 'MaxColumns', envVar: 'DB_MAX_COLUMNS', _default: 1000 }
+  { name: 'MaxColumns', envVar: 'DB_MAX_COLUMNS', _default: 1000 },
+  { name: 'BehindProxy', envVar: 'BEHIND_PROXY', _default: true } // set to FALSE to ignore proxy headers such as "X-Forwarded-Proto"
 ]
 
 function envCopy () {

--- a/src/service.js
+++ b/src/service.js
@@ -12,11 +12,12 @@ const BasicAuth = require('basic-auth')
 
 const { DB } = require('./maria')
 const { Dataset, Query, RecordPrinter } = require('./ddf')
-const { AllowCaching, HTTPPort, CPUThrottle, DBThrottle } = require('./env')
+const { AllowCaching, BehindProxy, HTTPPort, CPUThrottle, DBThrottle } = require('./env')
 const Log = require('./log')('service')
 
-module.exports.DDFService = function (forTesting = false) {
+module.exports.DDFService = function (forTesting = false, behindProxy = true) {
   const app = new Koa()
+  app.proxy = BehindProxy
   const api = new Router() // routes for the main API
 
   const loaderIOToken = process.env.LOADER_IO_TOKEN

--- a/src/service.js
+++ b/src/service.js
@@ -15,7 +15,7 @@ const { Dataset, Query, RecordPrinter } = require('./ddf')
 const { AllowCaching, BehindProxy, HTTPPort, CPUThrottle, DBThrottle } = require('./env')
 const Log = require('./log')('service')
 
-module.exports.DDFService = function (forTesting = false, behindProxy = true) {
+module.exports.DDFService = function (forTesting = false) {
   const app = new Koa()
   app.proxy = BehindProxy
   const api = new Router() // routes for the main API


### PR DESCRIPTION
By default Koa ignores proxy headers such as "X-Forwarded-Proto", this fix sets the Koa app.proxy to true by default, which honors uch headers.