### PR TITLE
Error handling and 400 for unknown concepts.

### DIFF
--- a/src/ddf/datasets.js
+++ b/src/ddf/datasets.js
@@ -259,7 +259,11 @@ class DDFSchema {
         const tableColumn = this.domains[column] || column
         const columnName = tableName ? `${tableName}.${tableColumn}` : tableColumn
         let condition = filter[column] // condition is either an object, or one of boolean, number, string or "variable" like '$geo'
-        if (typeof condition === 'object') {
+        if (condition === null) { // but every now and then the condition is "null", which should not be allowed
+          const whereErr = QuerySyntaxError.WrongWhere()
+          whereErr.message = `Invalid where clause ${column ? `for ${column}` : ''}. Condition is "null".`
+          throw whereErr
+        } else if (typeof condition === 'object') {
           if (Object.keys(condition).length > 1) {
             // make the implicit $and explicit
             filters.push({ $and: Object.keys(condition).reduce((subFilters, operator) => {

--- a/src/service.js
+++ b/src/service.js
@@ -11,7 +11,7 @@ const Urlon = require('urlon')
 const BasicAuth = require('basic-auth')
 
 const { DB } = require('./maria')
-const { Dataset, Query, RecordPrinter } = require('./ddf')
+const { Dataset, Query, QueryError, RecordPrinter } = require('./ddf')
 const { AllowCaching, BehindProxy, HTTPPort, CPUThrottle, DBThrottle } = require('./env')
 const Log = require('./log')('service')
 
@@ -131,6 +131,9 @@ module.exports.DDFService = function (forTesting = false) {
         ctx.throw(401, 'Unauthorized')
       } else if (err.code === 'DDF_DATASET_NOT_FOUND') {
         ctx.throw(404, err.message)
+      } else if (err instanceof QueryError) {
+        Log.warn({ err, req: ctx.request, ddfQuery: json })
+        ctx.throw(400, err.message)
       } else if (err.code === 'ER_GET_CONNECTION_TIMEOUT') {
         Log.warn('DDF query request timed out')
         ctx.throw(503, `Sorry, the DDF Service seems too busy, try again later`)

--- a/src/service.js
+++ b/src/service.js
@@ -142,6 +142,10 @@ module.exports.DDFService = function (forTesting = false) {
           Log.warn(err.sql)
           delete err.sql
         }
+        if (err.code === 'ER_BAD_FIELD_ERROR') {
+          const shortMsg = err.message.match(/Unknown column \S*\s/)
+          ctx.throw(400, shortMsg ? shortMsg[0].replace('column', 'concept') : 'DDF query seems to refer to an unknown concept')
+        }
         Log.warn({ err, req: ctx.request, ddfQuery: json }, `Unknown error: ${err.message}`)
       }
       ctx.throw(500, `Sorry, the DDF Service seems to have a problem, try again later`)


### PR DESCRIPTION
Handling of one kind of SQL error that may get detected first during the query. There are many possibilities for such errors, but in practice they are very rare. This particular one seems to occur more often probably because of a bug in the Gapminder tools page.