### PR TITLE
Quick fix to see if we can control GC logging issues.

### DIFF
--- a/src/log-google.js
+++ b/src/log-google.js
@@ -1,9 +1,40 @@
+const { Transform } = require('stream')
 const { LoggingBunyan } = require('@google-cloud/logging-bunyan')
 
 const GoogleLogLevel = process.env.GOOGLE_LOG_LEVEL || process.env.LOG_LEVEL || 'info'
 const GoogleLogName = process.env.GOOGLE_LOG_NAME || 'master'
 
+const RecordLimit = 200
+const ShorterMessageLength = 30
+
 module.exports = (logger) => {
+  const logRecordLimiter = new Transform({
+    objectMode: true,
+
+    transform (obj, encoding, callback) {
+      const str = JSON.stringify(obj)
+      if (str.length > RecordLimit) {
+        logger.warn('Received a too long log record!')
+        const smallerObj = {
+          hostname: obj.hostname,
+          level: obj.level,
+          msg: obj.msg.slice(0, ShorterMessageLength),
+          name: obj.name,
+          pid: obj.pid,
+          time: obj.time,
+          v: obj.v
+        }
+        if (obj.module) {
+          smallerObj.module = obj.module
+        }
+        this.push(smallerObj)
+        callback()
+      } else {
+        this.push(obj)
+        callback()
+      }
+    }
+  })
   const googleLog = new LoggingBunyan({
     logName: GoogleLogName,
     projectId: 'big-waffle',
@@ -12,6 +43,6 @@ module.exports = (logger) => {
       version: 1
     }
   })
-
-  logger.addStream(googleLog.stream(GoogleLogLevel))
+  logRecordLimiter.pipe(googleLog.stream(GoogleLogLevel).stream, { end: false })
+  logger.addStream({ level: GoogleLogLevel, type: 'raw', stream: logRecordLimiter })
 }

--- a/src/log-google.js
+++ b/src/log-google.js
@@ -4,8 +4,8 @@ const { LoggingBunyan } = require('@google-cloud/logging-bunyan')
 const GoogleLogLevel = process.env.GOOGLE_LOG_LEVEL || process.env.LOG_LEVEL || 'info'
 const GoogleLogName = process.env.GOOGLE_LOG_NAME || 'master'
 
-const RecordLimit = 200
-const ShorterMessageLength = 30
+const RecordLimit = 50000
+const ShorterMessageLength = 10000
 
 module.exports = (logger) => {
   const logRecordLimiter = new Transform({


### PR DESCRIPTION
Somehow the update google cloud library for bunyan logging complains about too long logging records. This code transforms such records into smaller ones.