### PR TITLE
Drop temporary csv table if exists before attempting to create a new one

### DIFF
--- a/src/collections.js
+++ b/src/collections.js
@@ -217,12 +217,17 @@ class Collection {
       }
       return `${statement} \`${columnName}\` ${type},`
     }, '')
-    let sql = `DROP TABLE IF EXISTS ${csvTableName};
-    CREATE TABLE ${csvTableName} (${columnDefs.slice(0, -1)}) 
-    engine=CONNECT table_type=CSV file_name='${path}' header=1 sep_char='${delimiter}' quoted=1;`
-    Log.debug(sql)
     const conn = await this.getConnection()
+    
+    let sql = `DROP TABLE IF EXISTS ${csvTableName};`
+    Log.debug(sql)
     await conn.query(sql)
+
+    sql = `CREATE TABLE ${csvTableName} (${columnDefs.slice(0, -1)}) 
+    engine=CONNECT table_type=CSV file_name='${path}' header=1 sep_char='${delimiter}' quoted=1;`
+    Log.debug(sql)    
+    await conn.query(sql)
+    
     return csvTableName
   }
 

--- a/src/collections.js
+++ b/src/collections.js
@@ -217,7 +217,8 @@ class Collection {
       }
       return `${statement} \`${columnName}\` ${type},`
     }, '')
-    let sql = `CREATE TABLE ${csvTableName} (${columnDefs.slice(0, -1)}) 
+    let sql = `DROP TABLE IF EXISTS ${csvTableName};
+    CREATE TABLE ${csvTableName} (${columnDefs.slice(0, -1)}) 
     engine=CONNECT table_type=CSV file_name='${path}' header=1 sep_char='${delimiter}' quoted=1;`
     Log.debug(sql)
     const conn = await this.getConnection()


### PR DESCRIPTION
This is a workaround for the following error:

```
{"name":"BigWaffle","hostname":"master","pid":12345,"module":"datasets","level":50,"err":{"message":"(conn=1085, no: 1050, SQLState: 42S01) Table 'TT15e31a33c99c45546b27d3f96eb5aacb' already exists\nsql: CREATE TABLE TT15e31a33c99c45546b27d3f96eb5aacb ( `geo` VARCHAR(9), `time` INTEGER, `abscorrup_idea` DOUBLE NOT NULL) \n    engine=CONNECT table_type=CSV file_name='/gapminders/github/tmp/fasttrackQA/ddf--datapoints--abscorrup_idea--by--country--time.csv' header=1 sep_char=',' quoted=1; - parameters:[]","name":"Error","stack":"Error: (conn=1085, no: 1050, SQLState: 42S01) Table 'TT15e31a33c99c45546b27d3f96eb5aacb' already exists\nsql: CREATE TABLE TT15e31a33c99c45546b27d3f96eb5aacb ( `geo` VARCHAR(9), `time` INTEGER, `abscorrup_idea` DOUBLE NOT NULL) \n    engine=CONNECT table_type=CSV file_name='/gapminders/github/tmp/fasttrackQA/ddf--datapoints--abscorrup_idea--by--country--time.csv' header=1 sep_char=',' quoted=1; - parameters:[]\n    at Object.module.exports.createError (/gapminders/big-waffle/node_modules/mariadb/lib/misc/errors.js:55:10)\n    at PacketNodeEncoded.readError (/gapminders/big-waffle/node_modules/mariadb/lib/io/packet.js:510:19)\n    at Query.readResponsePacket (/gapminders/big-waffle/node_modules/mariadb/lib/cmd/resultset.js:46:28)\n    at PacketInputStream.receivePacketBasic (/gapminders/big-waffle/node_modules/mariadb/lib/io/packet-input-stream.js:104:9)\n    at PacketInputStream.onData (/gapminders/big-waffle/node_modules/mariadb/lib/io/packet-input-stream.js:160:20)\n    at Socket.emit (events.js:210:5)\n    at addChunk (_stream_readable.js:309:12)\n    at readableAddChunk (_stream_readable.js:290:11)\n    at Socket.Readable.push (_stream_readable.js:224:10)\n    at TCP.onStreamRead (internal/stream_base_commons.js:182:23)","code":"ER_TABLE_EXISTS_ERROR"},"msg":"(conn=1085, no: 1050, SQLState: 42S01) Table 'TT15e31a33c99c45546b27d3f96eb5aacb' already exists\nsql: CREATE TABLE TT15e31a33c99c45546b27d3f96eb5aacb ( `geo` VARCHAR(9), `time` INTEGER, `abscorrup_idea` DOUBLE NOT NULL) \n    engine=CONNECT table_type=CSV file_name='/gapminders/github/tmp/fasttrackQA/ddf--datapoints--abscorrup_idea--by--country--time.csv' header=1 sep_char=',' quoted=1; - parameters:[]","time":"2021-09-02T10:32:10.311Z","v":0}
```

The reason the table existed already was probably that the instance ran out of space when attempting a particular import and thus never had a chance to  (source: @angieskazka). Another possible solutions is to manually delete ghost tables if they crop up in the future:

```
gcloud compute ssh --zone "europe-north1-a" "big-waffle-master" --project "big-waffle"
```

When inside, run:
```
sudo su
su github
mysql -u$DB_USER -p$DB_PWD -h localhost -A
```

When at the MySQL prompt, run:
```
USE gapminder;
```

Then remove the specific ghost table, e.g.:
```
MariaDB [gapminder]> DROP TABLE TT15e31a33c99c45546b27d3f96eb5aacb;
Query OK, 0 rows affected (0.002 sec)
MariaDB [gapminder]> DROP TABLE TT15e31a33c99c45546b27d3f96eb5aacb;
ERROR 1051 (42S02): Unknown table 'gapminder.TT15e31a33c99c45546b27d3f96eb5aacb'
```

@angieskazka I have not tested this code fyi.